### PR TITLE
Get pip from crossenv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: pip install . --no-deps --ignore-installed --no-cache-dir
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir
   skip: true  # [py27]
 
 requirements:


### PR DESCRIPTION
This may help pip build e.g. `sncosmo-2.4.0-cp38-cp38-macosx_11_0_arm64.whl` when cross-compiling from osx_64 -> osx_arm64, instead of `sncosmo-2.4.0-cp38-cp38-macosx_11_0_x86_64.whl`.